### PR TITLE
Make gravatar urls use https

### DIFF
--- a/magi/models.py
+++ b/magi/models.py
@@ -29,7 +29,7 @@ def avatar(user, size=200):
         default = django_settings.DEBUG_AVATAR
     if user.preferences.twitter:
         default = u'{}twitter_avatar/{}/'.format(SITE_URL if SITE_URL.startswith('http') else 'http:' + SITE_URL, user.preferences.twitter)
-    return ("http://www.gravatar.com/avatar/"
+    return ("https://www.gravatar.com/avatar/"
             + hashlib.md5(user.email.lower()).hexdigest()
             + "?" + urllib.urlencode({'d': default, 's': str(size)}))
 


### PR DESCRIPTION
Gets rid of one source of mixed content warnings. This still works even if the main page isn't loaded over https.

I left the default url as http since https still isn't the default for most servers, and for end-users gravatar's proxy is going to serve the image over https anyway.