### PR TITLE
Make links in other_sites HTTPS

### DIFF
--- a/magi/raw.py
+++ b/magi/raw.py
@@ -21,7 +21,7 @@ other_sites = [
         'name': 'School Idol Tomodachi',
         'game_name': 'LoveLive! School Idol Festival',
         'image': 'https://i.schoolido.lu/static/sukutomo.png',
-        'url': 'http://schoolido.lu/',
+        'url': 'https://schoolido.lu/',
     },
     {
         'name': 'Cinderella Producers',
@@ -38,7 +38,7 @@ other_sites = [
     {
         'name': 'Maji Love',
         'game_name': string_concat(_(u'Utano☆Princesama'), ' ', _(u'Shining Live')),
-        'image': 'http://i.maji.love/static/img/avatar.png',
+        'image': 'https://i.maji.love/static/img/avatar.png',
         'url': 'https://maji.love/',
     },
     {


### PR DESCRIPTION
This fixes the mixed content warning on every banpa page currently, and saves a redirect for SIT.